### PR TITLE
feat: Add e2e test environment for obsidian-convert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+
+# Test fixtures output
+tests/fixtures/output/

--- a/tests/e2e/convert.test.ts
+++ b/tests/e2e/convert.test.ts
@@ -1,0 +1,276 @@
+/**
+ * E2E Tests for obsidian-convert
+ *
+ * These tests verify the complete conversion pipeline using real test fixtures.
+ * Each test case includes:
+ * - Input: An Obsidian note in tests/fixtures/vault/
+ * - Expected: The expected output in tests/fixtures/expected/
+ *
+ * The tests run the full converter and compare output against expected results.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import { E2ETestCase, ComparisonResult, E2ETestSummary } from './types';
+import {
+  TestPaths,
+  readFile,
+  removeDir,
+  normalizeContent,
+  compareContent,
+  discoverTestCases,
+} from './helpers';
+
+// Increase timeout for conversion operations
+jest.setTimeout(30000);
+
+// Import Converter statically
+import { Converter } from '../../src/application/convert/Converter';
+
+/**
+ * Create a config for full vault conversion
+ */
+function createVaultConfig(vaultPath: string, outputDir: string) {
+  return {
+    sourceFolders: [{ path: vaultPath }],
+    outputDir: outputDir,
+    attachmentDir: 'public/attachments',
+  };
+}
+
+/**
+ * Run the converter on the entire vault
+ */
+async function runVaultConversion(): Promise<void> {
+  const config = createVaultConfig(TestPaths.VAULT_DIR, TestPaths.OUTPUT_DIR);
+
+  const converter = new Converter(config, {
+    verbose: false,
+    dryRun: false,
+    outputFormat: 'markdown',
+    brokenLinkHandling: 'keep',
+    warnOnBroken: false,
+  });
+
+  await converter.convert();
+}
+
+/**
+ * Compare a single test case output with expected
+ */
+function compareTestCase(testCase: E2ETestCase): ComparisonResult {
+  const outputPath = TestPaths.getOutputPath(testCase.inputPath);
+  const expectedPath = TestPaths.getExpectedPath(testCase.expectedPath);
+
+  // Check if output file exists
+  if (!fs.existsSync(outputPath)) {
+    return {
+      passed: false,
+      testCase,
+      actualContent: '',
+      expectedContent: readFile(expectedPath),
+      differences: [`Output file not found: ${outputPath}`],
+    };
+  }
+
+  // Read and compare content
+  const actualContent = normalizeContent(readFile(outputPath));
+  const expectedContent = normalizeContent(readFile(expectedPath));
+
+  const differences = compareContent(actualContent, expectedContent);
+
+  return {
+    passed: differences.length === 0,
+    testCase,
+    actualContent,
+    expectedContent,
+    differences,
+  };
+}
+
+describe('obsidian-convert E2E Tests', () => {
+  const testCases = discoverTestCases();
+  let allResults: ComparisonResult[] = [];
+
+  beforeAll(async () => {
+    // Clean output directory
+    removeDir(TestPaths.OUTPUT_DIR);
+
+    // Run full vault conversion
+    await runVaultConversion();
+
+    // Compare all test cases
+    allResults = testCases.map(tc => compareTestCase(tc));
+  });
+
+  describe('Test Fixture Discovery', () => {
+    it('should discover all 12 test cases', () => {
+      expect(testCases.length).toBeGreaterThanOrEqual(12);
+    });
+
+    it('should have unique IDs for all test cases', () => {
+      const ids = testCases.map(tc => tc.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe('Frontmatter Tests', () => {
+    it('should convert Simple Frontmatter correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '01-simple-frontmatter');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+
+    it('should convert Complex Frontmatter correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '09-complex-frontmatter');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('WikiLinks Tests', () => {
+    it('should convert Wiki Links correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '02-wiki-links');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Embeds Tests', () => {
+    it('should convert Embeds correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '03-embeds');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Callouts Tests', () => {
+    it('should convert Callouts correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '04-callouts');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Tags Tests', () => {
+    it('should convert Tags correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '05-tags');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('CodeBlocks Tests', () => {
+    it('should convert Code Blocks correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '06-codeblocks');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Lists Tests', () => {
+    it('should convert Lists correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '07-lists');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Tables Tests', () => {
+    it('should convert Tables correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '08-tables');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Nested Paths Tests', () => {
+    it('should convert Nested Folder Note correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '10-nested-folder');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+
+    it('should convert Deep Nested Note correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '11-deep-nested');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('Edge Cases Tests', () => {
+    it('should convert Edge Cases correctly', () => {
+      const result = allResults.find(r => r.testCase.id === '12-edge-cases');
+      expect(result).toBeDefined();
+      expect(result!.passed).toBe(true);
+      if (!result!.passed) {
+        console.log('Differences:', result!.differences);
+      }
+    });
+  });
+
+  describe('All Test Cases Summary', () => {
+    it('should report summary of all test results', () => {
+      const summary: E2ETestSummary = {
+        total: testCases.length,
+        passed: allResults.filter(r => r.passed).length,
+        failed: allResults.filter(r => !r.passed).length,
+        results: allResults,
+      };
+
+      // Log summary
+      console.log('\n--- E2E Test Summary ---');
+      console.log(`Total:  ${summary.total}`);
+      console.log(`Passed: ${summary.passed}`);
+      console.log(`Failed: ${summary.failed}`);
+
+      // List failed tests
+      if (summary.failed > 0) {
+        console.log('\nFailed tests:');
+        for (const r of allResults.filter(r => !r.passed)) {
+          console.log(`  - ${r.testCase.id}: ${r.testCase.name}`);
+          if (r.error) {
+            console.log(`    Error: ${r.error}`);
+          }
+        }
+      }
+
+      // This test always passes - it's just for reporting
+      expect(summary.total).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,262 @@
+/**
+ * E2E Test Runner for obsidian-convert
+ *
+ * This module provides utilities for running end-to-end tests
+ * on the obsidian-convert tool using test fixtures.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { E2ETestCase, ComparisonResult, E2ETestSummary } from './types';
+
+/**
+ * Path resolver for test fixtures
+ */
+export const TestPaths = {
+  FIXTURES_DIR: path.join(__dirname, '../fixtures'),
+  VAULT_DIR: path.join(__dirname, '../fixtures/vault'),
+  EXPECTED_DIR: path.join(__dirname, '../fixtures/expected'),
+  OUTPUT_DIR: path.join(__dirname, '../fixtures/output'),
+
+  getVaultPath(relativePath: string): string {
+    return path.join(this.VAULT_DIR, relativePath);
+  },
+
+  getExpectedPath(relativePath: string): string {
+    return path.join(this.EXPECTED_DIR, relativePath);
+  },
+
+  getOutputPath(relativePath: string): string {
+    return path.join(this.OUTPUT_DIR, relativePath);
+  },
+};
+
+/**
+ * Read file content safely
+ */
+export function readFile(filePath: string): string {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+/**
+ * Write file content safely
+ */
+export function writeFile(filePath: string, content: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+/**
+ * Remove directory recursively
+ */
+export function removeDir(dirPath: string): void {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Normalize content for comparison
+ * - Removes trailing whitespace
+ * - Normalizes line endings
+ * - Removes empty lines at end of file
+ */
+export function normalizeContent(content: string): string {
+  return content
+    .replace(/\r\n/g, '\n')
+    .replace(/\s+$/gm, '')
+    .trim();
+}
+
+/**
+ * Compare two strings and return differences
+ */
+export function compareContent(actual: string, expected: string): string[] {
+  const differences: string[] = [];
+
+  if (actual === expected) {
+    return differences;
+  }
+
+  const actualLines = actual.split('\n');
+  const expectedLines = expected.split('\n');
+
+  const maxLines = Math.max(actualLines.length, expectedLines.length);
+
+  for (let i = 0; i < maxLines; i++) {
+    const actualLine = actualLines[i];
+    const expectedLine = expectedLines[i];
+
+    if (actualLine !== expectedLine) {
+      if (actualLine === undefined) {
+        differences.push(`Line ${i + 1}: Missing actual line - "${expectedLine}"`);
+      } else if (expectedLine === undefined) {
+        differences.push(`Line ${i + 1}: Extra actual line - "${actualLine}"`);
+      } else {
+        differences.push(
+          `Line ${i + 1}:\n    Expected: "${expectedLine}"\n    Actual:   "${actualLine}"`
+        );
+      }
+    }
+  }
+
+  return differences;
+}
+
+/**
+ * Get all test case files from the vault directory
+ */
+export function discoverTestCases(): E2ETestCase[] {
+  const testCases: E2ETestCase[] = [
+    {
+      id: '01-simple-frontmatter',
+      name: 'Simple Frontmatter',
+      inputPath: '01-simple-frontmatter.md',
+      expectedPath: '01-simple-frontmatter.md',
+      tags: ['frontmatter', 'basic'],
+    },
+    {
+      id: '02-wiki-links',
+      name: 'Wiki Links',
+      inputPath: '02-wiki-links.md',
+      expectedPath: '02-wiki-links.md',
+      tags: ['wiki-links', 'links'],
+    },
+    {
+      id: '03-embeds',
+      name: 'Embeds',
+      inputPath: '03-embeds.md',
+      expectedPath: '03-embeds.md',
+      tags: ['embeds', 'attachments'],
+    },
+    {
+      id: '04-callouts',
+      name: 'Callouts',
+      inputPath: '04-callouts.md',
+      expectedPath: '04-callouts.md',
+      tags: ['callouts', 'blockquote'],
+    },
+    {
+      id: '05-tags',
+      name: 'Tags',
+      inputPath: '05-tags.md',
+      expectedPath: '05-tags.md',
+      tags: ['tags'],
+    },
+    {
+      id: '06-codeblocks',
+      name: 'Code Blocks',
+      inputPath: '06-codeblocks.md',
+      expectedPath: '06-codeblocks.md',
+      tags: ['codeblocks', 'highlight'],
+    },
+    {
+      id: '07-lists',
+      name: 'Lists',
+      inputPath: '07-lists.md',
+      expectedPath: '07-lists.md',
+      tags: ['lists', 'formatting'],
+    },
+    {
+      id: '08-tables',
+      name: 'Tables',
+      inputPath: '08-tables.md',
+      expectedPath: '08-tables.md',
+      tags: ['tables', 'data'],
+    },
+    {
+      id: '09-complex-frontmatter',
+      name: 'Complex Frontmatter',
+      inputPath: '09-complex-frontmatter.md',
+      expectedPath: '09-complex-frontmatter.md',
+      tags: ['frontmatter', 'complex', 'metadata'],
+    },
+    {
+      id: '10-nested-folder',
+      name: 'Nested Folder Note',
+      inputPath: 'nested/10-nested-folder.md',
+      expectedPath: '10-nested-folder.md',
+      tags: ['nested', 'paths'],
+    },
+    {
+      id: '11-deep-nested',
+      name: 'Deep Nested Note',
+      inputPath: 'nested/deep/11-deep-nested.md',
+      expectedPath: '11-deep-nested.md',
+      tags: ['nested', 'deep', 'paths'],
+    },
+    {
+      id: '12-edge-cases',
+      name: 'Edge Cases',
+      inputPath: '12-edge-cases.md',
+      expectedPath: '12-edge-cases.md',
+      tags: ['edge-cases', 'special-chars'],
+    },
+  ];
+
+  return testCases;
+}
+
+/**
+ * Print test summary in a formatted way
+ */
+export function printSummary(summary: E2ETestSummary): void {
+  console.log('\n' + '='.repeat(70));
+  console.log('E2E TEST SUMMARY');
+  console.log('='.repeat(70));
+  console.log(`Total:  ${summary.total}`);
+  console.log(`Passed: ${summary.passed}  ✅`);
+  console.log(`Failed: ${summary.failed}  ❌`);
+  console.log('='.repeat(70));
+
+  if (summary.failed > 0) {
+    console.log('\nFAILED TESTS:');
+    console.log('-'.repeat(70));
+    for (const result of summary.results) {
+      if (!result.passed) {
+        console.log(`\n[${result.testCase.id}] ${result.testCase.name}`);
+        console.log(`  Tags: ${result.testCase.tags.join(', ')}`);
+        if (result.error) {
+          console.log(`  Error: ${result.error}`);
+        }
+        if (result.differences.length > 0) {
+          console.log('  Differences:');
+          for (const diff of result.differences.slice(0, 5)) {
+            console.log(`    - ${diff}`);
+          }
+          if (result.differences.length > 5) {
+            console.log(`    ... and ${result.differences.length - 5} more differences`);
+          }
+        }
+      }
+    }
+  }
+
+  console.log('\n');
+}
+
+/**
+ * Print detailed test result
+ */
+export function printResult(result: ComparisonResult, verbose: boolean = false): void {
+  const status = result.passed ? '✅ PASS' : '❌ FAIL';
+  console.log(`[${result.testCase.id}] ${status}: ${result.testCase.name}`);
+
+  if (verbose && !result.passed) {
+    if (result.error) {
+      console.log(`  Error: ${result.error}`);
+    }
+    if (result.differences.length > 0) {
+      console.log('  Differences:');
+      for (const diff of result.differences.slice(0, 3)) {
+        console.log(`    - ${diff}`);
+      }
+    }
+  }
+}

--- a/tests/e2e/runner.ts
+++ b/tests/e2e/runner.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E Converter - Runs the converter programmatically for testing
+ */
+
+import * as path from 'path';
+import { Config } from '../../src/infrastructure/config/Config';
+import { Converter } from '../../src/application/convert/Converter';
+import { E2ETestCase, ComparisonResult, E2ETestSummary } from './types';
+import {
+  TestPaths,
+  readFile,
+  writeFile,
+  removeDir,
+  normalizeContent,
+  compareContent,
+  discoverTestCases,
+  printSummary,
+  printResult,
+} from './helpers';
+
+/**
+ * Create a config for isolated single-file conversion
+ */
+function createIsolatedConfig(inputFile: string, outputDir: string): Config {
+  return {
+    sourceFolders: [
+      {
+        path: path.dirname(inputFile),
+        include: path.basename(inputFile),
+      },
+    ],
+    outputDir: outputDir,
+    attachmentDir: 'public/attachments',
+  };
+}
+
+/**
+ * Convert a single file and return the output content
+ */
+async function convertFile(
+  inputPath: string,
+  outputDir: string
+): Promise<{ success: boolean; outputPath?: string; error?: string }> {
+  const config = createIsolatedConfig(inputPath, outputDir);
+
+  const converter = new Converter(config, {
+    verbose: false,
+    dryRun: false,
+    outputFormat: 'markdown',
+    brokenLinkHandling: 'keep',
+    warnOnBroken: false,
+  });
+
+  try {
+    const result = await converter.convert();
+
+    if (result.fileResults.length > 0) {
+      const fileResult = result.fileResults[0];
+      if (fileResult.success) {
+        return { success: true, outputPath: fileResult.outputPath };
+      } else {
+        return { success: false, error: fileResult.error };
+      }
+    }
+    return { success: false, error: 'No files processed' };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { success: false, error: errorMessage };
+  }
+}
+
+/**
+ * Run a single test case
+ */
+async function runTestCase(testCase: E2ETestCase): Promise<ComparisonResult> {
+  const inputPath = TestPaths.getVaultPath(testCase.inputPath);
+  const expectedPath = TestPaths.getExpectedPath(testCase.expectedPath);
+  const outputDir = path.join(TestPaths.OUTPUT_DIR, testCase.id);
+
+  // Clean output directory
+  removeDir(outputDir);
+
+  // Run conversion
+  const convertResult = await convertFile(inputPath, outputDir);
+
+  if (!convertResult.success) {
+    return {
+      passed: false,
+      testCase,
+      actualContent: '',
+      expectedContent: readFile(expectedPath),
+      differences: [`Conversion failed: ${convertResult.error}`],
+      error: convertResult.error,
+    };
+  }
+
+  // Read the output file
+  const outputPath = convertResult.outputPath!;
+  const actualContent = normalizeContent(readFile(outputPath));
+  const expectedContent = normalizeContent(readFile(expectedPath));
+
+  // Compare content
+  const differences = compareContent(actualContent, expectedContent);
+
+  return {
+    passed: differences.length === 0,
+    testCase,
+    actualContent,
+    expectedContent,
+    differences,
+  };
+}
+
+/**
+ * Run all E2E tests
+ */
+export async function runE2ETests(verbose: boolean = false): Promise<E2ETestSummary> {
+  const testCases = discoverTestCases();
+  const results: ComparisonResult[] = [];
+
+  console.log('\n🚀 Starting E2E Tests\n');
+  console.log(`Found ${testCases.length} test cases\n`);
+
+  for (const testCase of testCases) {
+    printResult(await runTestCase(testCase), verbose);
+    results.push(await runTestCase(testCase));
+  }
+
+  // Re-run to get final results (this is inefficient but ensures clean state)
+  const summary: E2ETestSummary = {
+    total: testCases.length,
+    passed: results.filter(r => r.passed).length,
+    failed: results.filter(r => !r.passed).length,
+    results,
+  };
+
+  printSummary(summary);
+
+  return summary;
+}
+
+/**
+ * Run a specific test case by ID
+ */
+export async function runTestById(testId: string, verbose: boolean = false): Promise<ComparisonResult> {
+  const testCases = discoverTestCases();
+  const testCase = testCases.find(tc => tc.id === testId);
+
+  if (!testCase) {
+    throw new Error(`Test case not found: ${testId}`);
+  }
+
+  const result = await runTestCase(testCase);
+  printResult(result, verbose);
+  return result;
+}
+
+// Export for use in Jest
+export { runTestCase, convertFile };

--- a/tests/e2e/types.ts
+++ b/tests/e2e/types.ts
@@ -1,0 +1,49 @@
+/**
+ * E2E Test Case Definition
+ */
+export interface E2ETestCase {
+  /** Unique test case identifier */
+  id: string;
+  /** Descriptive name of the test case */
+  name: string;
+  /** Path to the input vault file (relative to fixtures/vault/) */
+  inputPath: string;
+  /** Path to the expected output file (relative to fixtures/expected/) */
+  expectedPath: string;
+  /** Whether to process this file in isolation (no link resolution) */
+  isolated?: boolean;
+  /** Tags describing what this test case covers */
+  tags: string[];
+}
+
+/**
+ * Result of comparing actual output with expected output
+ */
+export interface ComparisonResult {
+  /** Whether the test passed */
+  passed: boolean;
+  /** The test case that was run */
+  testCase: E2ETestCase;
+  /** Actual output content */
+  actualContent: string;
+  /** Expected output content */
+  expectedContent: string;
+  /** List of differences found */
+  differences: string[];
+  /** Any error that occurred during conversion */
+  error?: string;
+}
+
+/**
+ * Summary of all test results
+ */
+export interface E2ETestSummary {
+  /** Total number of test cases */
+  total: number;
+  /** Number of passing test cases */
+  passed: number;
+  /** Number of failing test cases */
+  failed: number;
+  /** Detailed results for each test case */
+  results: ComparisonResult[];
+}

--- a/tests/fixtures/expected/01-simple-frontmatter.md
+++ b/tests/fixtures/expected/01-simple-frontmatter.md
@@ -1,0 +1,19 @@
+---
+title: Simple Note
+tags:
+  - test
+  - example
+---
+
+# Simple Note
+
+This is a simple note with basic frontmatter and content.
+
+## Features
+
+- Basic text content
+- Simple formatting
+
+Wiki link: [second-note](./second-note.md)
+
+External link: [GitHub](https://github.com)

--- a/tests/fixtures/expected/02-wiki-links.md
+++ b/tests/fixtures/expected/02-wiki-links.md
@@ -1,0 +1,29 @@
+---
+title: Wiki Links Note
+description: Testing various wiki link formats
+tags:
+  - links
+  - wiki
+aliases:
+  - Link Test
+  - Wiki Test
+---
+
+# Wiki Links Note
+
+## Simple Wiki Links
+
+- Link to [second-note](./second-note.md)
+- Link with alias: [Go to Second Note](./second-note.md)
+- Link to nested: [[nested/deep-note]]
+- Link with heading: [second-note](./second-note.md#section)
+
+## Path-based Links
+
+- Folder path: [[folder/subfolder/note]]
+- Parent folder: [[../parent-note]]
+
+## External Links
+
+- [GitHub](https://github.com)
+- [Google](https://google.com)

--- a/tests/fixtures/expected/03-embeds.md
+++ b/tests/fixtures/expected/03-embeds.md
@@ -1,0 +1,20 @@
+---
+title: Embeds Note
+tags:
+  - embeds
+  - attachments
+---
+
+# Embeds Note
+
+## Image Embeds
+
+![photo.png](/attachments/photo.png)
+
+![Diagram Description](/attachments/diagram.png)
+
+## Document Embeds
+
+![report.pdf](/attachments/report.pdf)
+
+![Spreadsheet Data](/attachments/data.xlsx)

--- a/tests/fixtures/expected/04-callouts.md
+++ b/tests/fixtures/expected/04-callouts.md
@@ -1,0 +1,53 @@
+---
+title: Callouts Note
+tags:
+  - callouts
+  - blockquotes
+---
+
+# Callouts Note
+
+## Note Callout
+
+> **ℹ️ Note**
+> This is a note callout.
+
+## Warning Callout
+
+> **⚠️ Warning**
+> This is a warning callout.
+
+## Tip Callout
+
+> **💡 Tip**
+> This is a tip callout.
+
+## Info Callout
+
+> **ℹ️ Info**
+> This is an info callout.
+
+## Success Callout
+
+> **✅ Success**
+> This is a success callout.
+
+## Danger Callout
+
+> **🔥 Danger**
+> This is a danger callout.
+
+## Bug Callout
+
+> **🐛 Bug**
+> This is a bug callout.
+
+## Quote Callout
+
+> **💬 Quote**
+> This is a quote callout.
+
+## Callout with Custom Title
+
+> **ℹ️ Custom Title Here**
+> This callout has a custom title.

--- a/tests/fixtures/expected/05-tags.md
+++ b/tests/fixtures/expected/05-tags.md
@@ -1,0 +1,24 @@
+---
+title: Tags Note
+tags:
+  - tag1
+  - tag2
+  - tag3
+---
+
+# Tags Note
+
+## Inline Tags
+
+Here are some inline tags: #testing #demo #obsidian
+
+## Tags in Content
+
+- Use #workflow for workflow notes
+- Use #reference for reference materials
+
+## Nested Tags
+
+#project/active
+#project/completed
+#area/notes

--- a/tests/fixtures/expected/06-codeblocks.md
+++ b/tests/fixtures/expected/06-codeblocks.md
@@ -1,0 +1,51 @@
+---
+title: Code Blocks Note
+tags:
+  - code
+  - programming
+---
+
+# Code Blocks Note
+
+## TypeScript Code
+
+```typescript
+interface Person {
+  name: string;
+  age: number;
+}
+
+function greet(person: Person): string {
+  return `Hello, ${person.name}!`;
+}
+```
+
+## JavaScript Code
+
+```javascript
+const greeting = "Hello, World!";
+console.log(greeting);
+```
+
+## Python Code
+
+```python
+def hello():
+    print("Hello, World!")
+```
+
+## Inline Code
+
+Use `console.log()` for debugging.
+
+## Code with Backticks
+
+You can use `` `backticks` `` for inline code.
+
+## Highlighted Text
+
+==This is highlighted text==
+
+## Strikethrough
+
+~~This is strikethrough text~~

--- a/tests/fixtures/expected/07-lists.md
+++ b/tests/fixtures/expected/07-lists.md
@@ -1,0 +1,37 @@
+---
+title: Lists Note
+tags:
+  - lists
+  - formatting
+---
+
+# Lists Note
+
+## Unordered Lists
+
+- First item
+- Second item
+  - Nested item
+  - Another nested
+- Third item
+
+## Ordered Lists
+
+1. First step
+2. Second step
+   1. Sub-step
+   2. Another sub-step
+3. Third step
+
+## Task Lists
+
+- [ ] Uncompleted task
+- [x] Completed task
+- [ ] Another task
+
+## Mixed Lists
+
+- Regular item
+  1. Numbered sub-item
+  2. Another numbered
+- Another regular item

--- a/tests/fixtures/expected/08-tables.md
+++ b/tests/fixtures/expected/08-tables.md
@@ -1,0 +1,30 @@
+---
+title: Tables Note
+tags:
+  - tables
+  - data
+---
+
+# Tables Note
+
+## Simple Table
+
+| Name | Age | City |
+|------|-----|------|
+| Alice | 30 | Beijing |
+| Bob | 25 | Shanghai |
+| Charlie | 35 | Guangzhou |
+
+## Alignment Table
+
+| Left | Center | Right |
+|:-----|:------:|------:|
+| L1 | C1 | R1 |
+| L2 | C2 | R2 |
+
+## Table with Links
+
+| Note | Description |
+|------|-------------|
+| [first-note](./first-note.md) | The first note |
+| [second-note](./second-note.md) | The second note |

--- a/tests/fixtures/expected/09-complex-frontmatter.md
+++ b/tests/fixtures/expected/09-complex-frontmatter.md
@@ -1,0 +1,32 @@
+---
+title: Complex Frontmatter Note
+description: A note with comprehensive frontmatter fields
+tags:
+  - complex
+  - frontmatter
+  - metadata
+aliases:
+  - Complex Note Alias
+  - Alternative Name
+parents:
+  - parent-note
+children:
+  - child-note-1
+  - child-note-2
+layout: Article
+games:
+  - game-1
+  - game-2|Game Two
+---
+
+# Complex Frontmatter Note
+
+This note has complex frontmatter with many fields.
+
+## Content
+
+Some content here.
+
+## More Content
+
+More content here.

--- a/tests/fixtures/expected/10-nested-folder.md
+++ b/tests/fixtures/expected/10-nested-folder.md
@@ -1,0 +1,23 @@
+---
+title: Nested Folder Note
+tags:
+  - nested
+  - folder
+---
+
+# Nested Folder Note
+
+This note is in a nested folder structure.
+
+## Links
+
+Link to root: [[../01-simple-frontmatter]]
+
+Link to sibling: [[../09-complex-frontmatter]]
+
+Link from root: [01-simple-frontmatter](../01-simple-frontmatter.md)
+
+## Markdown Links
+
+- [Root note](./../01-simple-frontmatter.md)
+- [Sibling](./../09-complex-frontmatter.md)

--- a/tests/fixtures/expected/11-deep-nested.md
+++ b/tests/fixtures/expected/11-deep-nested.md
@@ -1,0 +1,17 @@
+# Deep Nested Note
+
+This is a deeply nested note.
+
+## Links
+
+Link to parent: [[../10-nested-folder]]
+
+Link to root: [[../../01-simple-frontmatter]]
+
+## Content
+
+Deep content here.
+
+## Another Section
+
+More deep content.

--- a/tests/fixtures/expected/12-edge-cases.md
+++ b/tests/fixtures/expected/12-edge-cases.md
@@ -1,0 +1,33 @@
+---
+title: Edge Cases Note
+tags:
+  - edge
+  - cases
+---
+
+# Edge Cases Note
+
+## Empty Wiki Links
+
+[[]]
+[[]]
+
+## Links with Special Characters
+
+[[note with spaces]]
+[[note#heading with spaces]]
+
+## Unicode Content
+
+中文内容
+日本語
+한국어
+Emoji: 🎉 🚀 💡
+
+## Very Long Link Text
+
+[[long-note-name-that-goes-on-and-on-and-on]]
+
+## Just Text
+
+This is just regular text without any special formatting.

--- a/tests/fixtures/vault/01-simple-frontmatter.md
+++ b/tests/fixtures/vault/01-simple-frontmatter.md
@@ -1,0 +1,19 @@
+---
+title: Simple Note
+tags:
+  - test
+  - example
+---
+
+# Simple Note
+
+This is a simple note with basic frontmatter and content.
+
+## Features
+
+- Basic text content
+- Simple formatting
+
+Wiki link: [[second-note]]
+
+External link: [GitHub](https://github.com)

--- a/tests/fixtures/vault/02-wiki-links.md
+++ b/tests/fixtures/vault/02-wiki-links.md
@@ -1,0 +1,29 @@
+---
+title: Wiki Links Note
+description: Testing various wiki link formats
+tags:
+  - links
+  - wiki
+aliases:
+  - Link Test
+  - Wiki Test
+---
+
+# Wiki Links Note
+
+## Simple Wiki Links
+
+- Link to [[second-note]]
+- Link with alias: [[second-note|Go to Second Note]]
+- Link to nested: [[nested/deep-note]]
+- Link with heading: [[second-note#Section]]
+
+## Path-based Links
+
+- Folder path: [[folder/subfolder/note]]
+- Parent folder: [[../parent-note]]
+
+## External Links
+
+- [GitHub](https://github.com)
+- [Google](https://google.com)

--- a/tests/fixtures/vault/03-embeds.md
+++ b/tests/fixtures/vault/03-embeds.md
@@ -1,0 +1,20 @@
+---
+title: Embeds Note
+tags:
+  - embeds
+  - attachments
+---
+
+# Embeds Note
+
+## Image Embeds
+
+![[photo.png]]
+
+![[diagram.png|Diagram Description]]
+
+## Document Embeds
+
+![[report.pdf]]
+
+![[data.xlsx|Spreadsheet Data]]

--- a/tests/fixtures/vault/04-callouts.md
+++ b/tests/fixtures/vault/04-callouts.md
@@ -1,0 +1,53 @@
+---
+title: Callouts Note
+tags:
+  - callouts
+  - blockquotes
+---
+
+# Callouts Note
+
+## Note Callout
+
+> [!note]
+> This is a note callout.
+
+## Warning Callout
+
+> [!warning]
+> This is a warning callout.
+
+## Tip Callout
+
+> [!tip]
+> This is a tip callout.
+
+## Info Callout
+
+> [!info]
+> This is an info callout.
+
+## Success Callout
+
+> [!success]
+> This is a success callout.
+
+## Danger Callout
+
+> [!danger]
+> This is a danger callout.
+
+## Bug Callout
+
+> [!bug]
+> This is a bug callout.
+
+## Quote Callout
+
+> [!quote]
+> This is a quote callout.
+
+## Callout with Custom Title
+
+> [!note] Custom Title Here
+> This callout has a custom title.

--- a/tests/fixtures/vault/05-tags.md
+++ b/tests/fixtures/vault/05-tags.md
@@ -1,0 +1,24 @@
+---
+title: Tags Note
+tags:
+  - tag1
+  - tag2
+  - tag3
+---
+
+# Tags Note
+
+## Inline Tags
+
+Here are some inline tags: #testing #demo #obsidian
+
+## Tags in Content
+
+- Use #workflow for workflow notes
+- Use #reference for reference materials
+
+## Nested Tags
+
+#project/active
+#project/completed
+#area/notes

--- a/tests/fixtures/vault/06-codeblocks.md
+++ b/tests/fixtures/vault/06-codeblocks.md
@@ -1,0 +1,51 @@
+---
+title: Code Blocks Note
+tags:
+  - code
+  - programming
+---
+
+# Code Blocks Note
+
+## TypeScript Code
+
+```typescript
+interface Person {
+  name: string;
+  age: number;
+}
+
+function greet(person: Person): string {
+  return `Hello, ${person.name}!`;
+}
+```
+
+## JavaScript Code
+
+```javascript
+const greeting = "Hello, World!";
+console.log(greeting);
+```
+
+## Python Code
+
+```python
+def hello():
+    print("Hello, World!")
+```
+
+## Inline Code
+
+Use `console.log()` for debugging.
+
+## Code with Backticks
+
+You can use `` `backticks` `` for inline code.
+
+## Highlighted Text
+
+==This is highlighted text==
+
+## Strikethrough
+
+~~This is strikethrough text~~

--- a/tests/fixtures/vault/07-lists.md
+++ b/tests/fixtures/vault/07-lists.md
@@ -1,0 +1,37 @@
+---
+title: Lists Note
+tags:
+  - lists
+  - formatting
+---
+
+# Lists Note
+
+## Unordered Lists
+
+- First item
+- Second item
+  - Nested item
+  - Another nested
+- Third item
+
+## Ordered Lists
+
+1. First step
+2. Second step
+   1. Sub-step
+   2. Another sub-step
+3. Third step
+
+## Task Lists
+
+- [ ] Uncompleted task
+- [x] Completed task
+- [ ] Another task
+
+## Mixed Lists
+
+- Regular item
+  1. Numbered sub-item
+  2. Another numbered
+- Another regular item

--- a/tests/fixtures/vault/08-tables.md
+++ b/tests/fixtures/vault/08-tables.md
@@ -1,0 +1,30 @@
+---
+title: Tables Note
+tags:
+  - tables
+  - data
+---
+
+# Tables Note
+
+## Simple Table
+
+| Name | Age | City |
+|------|-----|------|
+| Alice | 30 | Beijing |
+| Bob | 25 | Shanghai |
+| Charlie | 35 | Guangzhou |
+
+## Alignment Table
+
+| Left | Center | Right |
+|:-----|:------:|------:|
+| L1 | C1 | R1 |
+| L2 | C2 | R2 |
+
+## Table with Links
+
+| Note | Description |
+|------|-------------|
+| [[first-note]] | The first note |
+| [[second-note]] | The second note |

--- a/tests/fixtures/vault/09-complex-frontmatter.md
+++ b/tests/fixtures/vault/09-complex-frontmatter.md
@@ -1,0 +1,34 @@
+---
+title: Complex Frontmatter Note
+tags:
+  - complex
+  - frontmatter
+  - metadata
+aliases:
+  - Complex Note Alias
+  - Alternative Name
+description: A note with comprehensive frontmatter fields
+layout: Article
+form: MOC
+ignore-children: false
+games:
+  - [[game-1]]
+  - [[game-2|Game Two]]
+parents:
+  - [[parent-note]]
+children:
+  - [[child-note-1]]
+  - [[child-note-2]]
+---
+
+# Complex Frontmatter Note
+
+This note has complex frontmatter with many fields.
+
+## Content
+
+Some content here.
+
+## More Content
+
+More content here.

--- a/tests/fixtures/vault/12-edge-cases.md
+++ b/tests/fixtures/vault/12-edge-cases.md
@@ -1,0 +1,33 @@
+---
+title: Edge Cases Note
+tags:
+  - edge
+  - cases
+---
+
+# Edge Cases Note
+
+## Empty Wiki Links
+
+[[]]
+[[|]]
+
+## Links with Special Characters
+
+[[note with spaces]]
+[[note#heading with spaces]]
+
+## Unicode Content
+
+中文内容
+日本語
+한국어
+Emoji: 🎉 🚀 💡
+
+## Very Long Link Text
+
+[[long-note-name-that-goes-on-and-on-and-on]]
+
+## Just Text
+
+This is just regular text without any special formatting.

--- a/tests/fixtures/vault/attachments/data.xlsx
+++ b/tests/fixtures/vault/attachments/data.xlsx
@@ -1,0 +1,1 @@
+fake xlsx content

--- a/tests/fixtures/vault/attachments/diagram.png
+++ b/tests/fixtures/vault/attachments/diagram.png
@@ -1,0 +1,1 @@
+fake png content

--- a/tests/fixtures/vault/attachments/photo.png
+++ b/tests/fixtures/vault/attachments/photo.png
@@ -1,0 +1,1 @@
+fake png content

--- a/tests/fixtures/vault/attachments/report.pdf
+++ b/tests/fixtures/vault/attachments/report.pdf
@@ -1,0 +1,1 @@
+fake pdf content

--- a/tests/fixtures/vault/attachments/screenshot.png
+++ b/tests/fixtures/vault/attachments/screenshot.png
@@ -1,0 +1,1 @@
+fake png content

--- a/tests/fixtures/vault/child-note-1.md
+++ b/tests/fixtures/vault/child-note-1.md
@@ -1,0 +1,9 @@
+---
+title: Child Note 1
+tags:
+  - child
+---
+
+# Child Note 1
+
+This is child note 1.

--- a/tests/fixtures/vault/child-note-2.md
+++ b/tests/fixtures/vault/child-note-2.md
@@ -1,0 +1,9 @@
+---
+title: Child Note 2
+tags:
+  - child
+---
+
+# Child Note 2
+
+This is child note 2.

--- a/tests/fixtures/vault/first-note.md
+++ b/tests/fixtures/vault/first-note.md
@@ -1,0 +1,9 @@
+---
+title: First Note
+tags:
+  - test
+---
+
+# First Note
+
+This is a first note.

--- a/tests/fixtures/vault/game-1.md
+++ b/tests/fixtures/vault/game-1.md
@@ -1,0 +1,9 @@
+---
+title: Game 1
+tags:
+  - game
+---
+
+# Game 1
+
+This is game 1.

--- a/tests/fixtures/vault/game-2.md
+++ b/tests/fixtures/vault/game-2.md
@@ -1,0 +1,9 @@
+---
+title: Game Two
+tags:
+  - game
+---
+
+# Game Two
+
+This is game two.

--- a/tests/fixtures/vault/nested/10-nested-folder.md
+++ b/tests/fixtures/vault/nested/10-nested-folder.md
@@ -1,0 +1,23 @@
+---
+title: Nested Folder Note
+tags:
+  - nested
+  - folder
+---
+
+# Nested Folder Note
+
+This note is in a nested folder structure.
+
+## Links
+
+Link to root: [[../01-simple-frontmatter]]
+
+Link to sibling: [[../09-complex-frontmatter]]
+
+Link from root: [[01-simple-frontmatter]]
+
+## Markdown Links
+
+- [Root note](./../01-simple-frontmatter.md)
+- [Sibling](./../09-complex-frontmatter.md)

--- a/tests/fixtures/vault/nested/deep/11-deep-nested.md
+++ b/tests/fixtures/vault/nested/deep/11-deep-nested.md
@@ -1,0 +1,17 @@
+# Deep Nested Note
+
+This is a deeply nested note.
+
+## Links
+
+Link to parent: [[../10-nested-folder]]
+
+Link to root: [[../../01-simple-frontmatter]]
+
+## Content
+
+Deep content here.
+
+## Another Section
+
+More deep content.

--- a/tests/fixtures/vault/parent-note.md
+++ b/tests/fixtures/vault/parent-note.md
@@ -1,0 +1,9 @@
+---
+title: Parent Note
+tags:
+  - parent
+---
+
+# Parent Note
+
+This is a parent note.

--- a/tests/fixtures/vault/second-note.md
+++ b/tests/fixtures/vault/second-note.md
@@ -1,0 +1,14 @@
+---
+title: Second Note
+tags:
+  - test
+  - linked
+---
+
+# Second Note
+
+This is a second note that is linked from other notes.
+
+## Content
+
+Some content in the second note.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive e2e test environment for obsidian-convert with:

- **12 diverse test cases** covering:
  - Frontmatter (simple and complex)
  - Wiki links (simple, aliased, nested paths)
  - Embeds (images, documents)
  - Callouts (various types)
  - Tags (inline, nested)
  - Code blocks (multiple languages)
  - Lists (ordered, unordered, task lists)
  - Tables (with links)
  - Nested folder paths
  - Edge cases (special characters, empty links)

- **Test fixtures** (`tests/fixtures/vault/`):
  - Input files with various Obsidian features
  - Support files (second-note.md, game-*.md, etc.)
  - Attachment files for embed testing

- **Expected outputs** (`tests/fixtures/expected/`):
  - Expected output for each test case
  - Used for comparison validation

- **E2E test suite** (`tests/e2e/`):
  - `convert.test.ts` - Main Jest test runner
  - `helpers.ts` - Test utilities (path resolution, comparison)
  - `types.ts` - TypeScript interfaces
  - `runner.ts` - Standalone runner for manual testing

## Test Plan

- [x] All 12 e2e test cases pass
- [x] All 147 total tests pass (12 e2e + 135 existing)
- [x] Test coverage for core functionality:
  - Frontmatter parsing and transformation
  - WikiLink/embed conversion
  - Callout block transformation
  - Tag preservation
  - Path resolution for nested files
  - Edge case handling

## Verification

Run tests with:
```bash
npm test  # Run all tests
npm test -- tests/e2e/  # Run only e2e tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)