### PR TITLE
feat: WikiLink Path Resolution Enhancement (Issue #11)

### DIFF
--- a/src/domain/link/LinkResolver.ts
+++ b/src/domain/link/LinkResolver.ts
@@ -35,6 +35,10 @@ export interface LinkResolutionResult {
   hasConflict?: boolean;
   /** All matching files if there was a conflict */
   conflictingFiles?: IndexedFile[];
+  /** Whether fuzzy matching was used to find this file */
+  hasFuzzyMatch?: boolean;
+  /** Levenshtein distance if fuzzy match was used */
+  fuzzyMatchDistance?: number;
 }
 
 /**
@@ -53,6 +57,12 @@ export interface LinkResolverOptions {
   autoIndex?: boolean;
   /** Verbose logging (default: false) */
   verbose?: boolean;
+  /** Enable fuzzy matching when exact match fails (default: false) */
+  fuzzyMatch?: boolean;
+  /** Maximum Levenshtein distance for fuzzy matching (default: 3) */
+  fuzzyMaxDistance?: number;
+  /** Warn when fuzzy match is used (default: true) */
+  warnOnFuzzyMatch?: boolean;
 }
 
 /**
@@ -82,6 +92,9 @@ export class LinkResolver {
   private readonly strictMode: boolean;
   private readonly autoIndex: boolean;
   private readonly verbose: boolean;
+  private readonly fuzzyMatch: boolean;
+  private readonly fuzzyMaxDistance: number;
+  private readonly warnOnFuzzyMatch: boolean;
   private readonly brokenLinks: string[] = [];
   private sourceRoots: string[] = [];
 
@@ -92,6 +105,9 @@ export class LinkResolver {
     this.strictMode = options.strictMode ?? false;
     this.autoIndex = options.autoIndex ?? true;
     this.verbose = options.verbose ?? false;
+    this.fuzzyMatch = options.fuzzyMatch ?? false;
+    this.fuzzyMaxDistance = options.fuzzyMaxDistance ?? 3;
+    this.warnOnFuzzyMatch = options.warnOnFuzzyMatch ?? true;
   }
 
   /**
@@ -132,9 +148,13 @@ export class LinkResolver {
     const basename = this.getBasename(normalizedTarget);
     const allMatches = this.findAllByBasename(basename);
 
-    // If no exact match but found basename matches, apply conflict resolution
-    if (!indexedFile && allMatches.length > 0) {
+    // If there are multiple files with same basename, apply conflict resolution
+    // even if an exact path match was found - to ensure we pick the nearest one
+    if (allMatches.length > 1) {
       indexedFile = this.resolveConflict(allMatches, currentFilePath, sourceRoot);
+    } else if (!indexedFile && allMatches.length === 1) {
+      // Single match by basename, use it
+      indexedFile = allMatches[0];
     }
 
     if (indexedFile) {
@@ -155,6 +175,35 @@ export class LinkResolver {
         isBroken: false,
         hasConflict,
         conflictingFiles: hasConflict ? allMatches : undefined,
+      };
+    }
+
+    // Link not found - try fuzzy matching if enabled
+    let fuzzyMatchedFile: IndexedFile | undefined;
+    let fuzzyDistance: number | undefined;
+
+    if (this.fuzzyMatch) {
+      const fuzzyResult = this.findFuzzyMatch(normalizedTarget, currentFilePath, sourceRoot);
+      if (fuzzyResult) {
+        fuzzyMatchedFile = fuzzyResult.file;
+        fuzzyDistance = fuzzyResult.distance;
+      }
+    }
+
+    if (fuzzyMatchedFile) {
+      this.handleFuzzyMatchWarning(target, fuzzyMatchedFile, fuzzyDistance!);
+
+      const currentDir = path.dirname(currentFilePath);
+      const relativePath = this.calculateRelativePath(currentDir, fuzzyMatchedFile.absolutePath, sourceRoot);
+
+      return {
+        found: true,
+        file: fuzzyMatchedFile,
+        relativePath,
+        isBroken: false,
+        hasConflict: false,
+        hasFuzzyMatch: true,
+        fuzzyMatchDistance: fuzzyDistance,
       };
     }
 
@@ -420,6 +469,98 @@ export class LinkResolver {
         `\nSelected: ${matches[0].relativePath}`
       );
     }
+  }
+
+  private handleFuzzyMatchWarning(target: string, matchedFile: IndexedFile, distance: number): void {
+    if (this.warnOnFuzzyMatch) {
+      console.warn(
+        `Warning: Link [[${target}]] was resolved using fuzzy match (distance: ${distance}):\n` +
+        `  Matched: ${matchedFile.relativePath}`
+      );
+    }
+  }
+
+  /**
+   * Find a fuzzy match for the target when exact match fails
+   */
+  private findFuzzyMatch(target: string, currentFilePath: string, sourceRoot: string): { file: IndexedFile; distance: number } | undefined {
+    const targetBasename = this.getBasename(target);
+    const targetDir = path.dirname(target);
+    const currentDir = path.dirname(currentFilePath);
+
+    let bestMatch: IndexedFile | undefined;
+    let bestDistance = Infinity;
+    let bestScore = Infinity;
+
+    for (const file of this.fileIndex.values()) {
+      // Calculate Levenshtein distance between target basename and file basename
+      const distance = this.levenshteinDistance(targetBasename, file.basename);
+
+      // Skip if distance exceeds maximum allowed
+      if (distance > this.fuzzyMaxDistance) {
+        continue;
+      }
+
+      // Calculate path proximity score (lower is better)
+      // Prefer files in the same directory or nearby directories
+      const fileDir = path.dirname(file.absolutePath);
+      const relativeToCurrent = path.relative(currentDir, fileDir);
+      const pathProximity = this.calculatePathDistance(relativeToCurrent);
+
+      // Combined score: weighted sum of edit distance and path proximity
+      // Path proximity is weighted less (multiplied by 0.5) since it's a secondary factor
+      const combinedScore = distance + pathProximity * 0.5;
+
+      if (combinedScore < bestScore) {
+        bestScore = combinedScore;
+        bestDistance = distance;
+        bestMatch = file;
+      }
+    }
+
+    if (bestMatch) {
+      this.log(`Fuzzy match found for [[${target}]]: ${bestMatch.relativePath} (distance: ${bestDistance})`);
+      return { file: bestMatch, distance: bestDistance };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Calculate Levenshtein (edit) distance between two strings
+   */
+  private levenshteinDistance(str1: string, str2: string): number {
+    const len1 = str1.length;
+    const len2 = str2.length;
+
+    // Create a matrix to store distances
+    const matrix: number[][] = Array(len1 + 1)
+      .fill(null)
+      .map(() => Array(len2 + 1).fill(0));
+
+    // Initialize first column
+    for (let i = 0; i <= len1; i++) {
+      matrix[i][0] = i;
+    }
+
+    // Initialize first row
+    for (let j = 0; j <= len2; j++) {
+      matrix[0][j] = j;
+    }
+
+    // Fill in the rest of the matrix
+    for (let i = 1; i <= len1; i++) {
+      for (let j = 1; j <= len2; j++) {
+        const cost = str1[i - 1] === str2[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,      // deletion
+          matrix[i][j - 1] + 1,      // insertion
+          matrix[i - 1][j - 1] + cost // substitution
+        );
+      }
+    }
+
+    return matrix[len1][len2];
   }
 
   private normalizePath(p: string): string {

--- a/src/domain/link/WikiLink.ts
+++ b/src/domain/link/WikiLink.ts
@@ -1,3 +1,5 @@
+import type { LinkResolver, LinkResolutionResult } from './LinkResolver';
+
 /**
  * WikiLink value object representing Obsidian [[link]] syntax
  */
@@ -45,6 +47,17 @@ export class WikiLink {
     }
 
     return new WikiLink(target, displayText, heading, isEmbed);
+  }
+
+  /**
+   * Resolve this wiki link's target to a file path using the provided resolver
+   * @param resolver - The LinkResolver instance
+   * @param currentFilePath - Path to the current file containing this link
+   * @param sourceRoot - Root source directory
+   * @returns The resolution result
+   */
+  resolvePath(resolver: LinkResolver, currentFilePath: string, sourceRoot: string): LinkResolutionResult {
+    return resolver.resolve(this.target, currentFilePath, sourceRoot);
   }
 
   /**

--- a/tests/unit/domain/link/LinkResolver.test.ts
+++ b/tests/unit/domain/link/LinkResolver.test.ts
@@ -317,4 +317,192 @@ describe('LinkResolver', () => {
       expect(trackingResolver.getBrokenLinks()).toHaveLength(0);
     });
   });
+
+  describe('fuzzy matching', () => {
+    beforeEach(async () => {
+      // Create test files with similar names
+      fs.writeFileSync(path.join(tempDir, 'introduction.md'), '');
+      fs.mkdirSync(path.join(tempDir, 'notes'));
+      fs.writeFileSync(path.join(tempDir, 'notes', 'introduction.md'), '');
+      fs.mkdirSync(path.join(tempDir, 'sub'));
+      fs.writeFileSync(path.join(tempDir, 'sub', 'note.md'), '');
+    });
+
+    it('should not use fuzzy match by default', async () => {
+      const resolver = new LinkResolver({ caseInsensitive: true });
+      await resolver.buildIndex([tempDir]);
+
+      // 'intruction' does NOT exist, 'introduction' does - without fuzzy, this should fail
+      const result = resolver.resolve('intruction', path.join(tempDir, 'test.md'), tempDir);
+      expect(result.found).toBe(false);
+      expect(result.isBroken).toBe(true);
+    });
+
+    it('should find fuzzy match when enabled', async () => {
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 3,
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // 'introdution' (missing 'c') is distance 1 from 'introduction'
+      // introdution vs introduction: missing 'c' at position 8
+      const result = fuzzyResolver.resolve('introdution', path.join(tempDir, 'test.md'), tempDir);
+      expect(result.found).toBe(true);
+      expect(result.hasFuzzyMatch).toBe(true);
+      expect(result.fuzzyMatchDistance).toBe(1);
+      expect(result.file?.basename).toBe('introduction');
+    });
+
+    it('should prefer nearest file when multiple basename matches exist', async () => {
+      const resolver = new LinkResolver({
+        caseInsensitive: true,
+        conflictStrategy: 'nearest',
+      });
+      await resolver.buildIndex([tempDir]);
+
+      // 'introduction' exists in both root and notes folder
+      // From notes/test.md, the nearest 'introduction' is notes/introduction.md
+      const result = resolver.resolve('introduction', path.join(tempDir, 'notes', 'test.md'), tempDir);
+
+      expect(result.found).toBe(true);
+      // The nearest match should be notes/introduction.md
+      expect(result.file?.relativePath).toBe('notes/introduction.md');
+    });
+
+    it('should not match if distance exceeds max', async () => {
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 1, // Only allow distance of 1
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // 'intruction' vs 'introduction' is distance 1, should match
+      // But 'introdction' vs 'introduction' is distance 2 (substitution + extra char)
+      // Actually let's use 'introductio' (missing n at end) - distance 1
+      const result = fuzzyResolver.resolve('introductio', path.join(tempDir, 'test.md'), tempDir);
+
+      expect(result.found).toBe(true);
+      expect(result.hasFuzzyMatch).toBe(true);
+      expect(result.fuzzyMatchDistance).toBe(1);
+    });
+
+    it('should not match when distance exceeds max', async () => {
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 1, // Only allow distance of 1
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // 'intruction' vs 'introduction' is distance 2, exceeds max of 1
+      // introdction: i-n-t-r-o-d-c-t-i-o-n (11 chars, missing u, wrong order)
+      // introduction: i-n-t-r-o-d-u-c-t-i-o-n (12 chars)
+      // This is about 3+ edits, definitely > 1
+      const result = fuzzyResolver.resolve('intruction', path.join(tempDir, 'test.md'), tempDir);
+
+      expect(result.found).toBe(false);
+      expect(result.isBroken).toBe(true);
+    });
+
+    it('should warn when fuzzy match is used', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 3,
+        warnOnFuzzyMatch: true,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // 'introdution' doesn't exist but 'introduction' does (distance 1)
+      fuzzyResolver.resolve('introdution', path.join(tempDir, 'test.md'), tempDir);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fuzzy match')
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when warnOnFuzzyMatch is false', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 3,
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      fuzzyResolver.resolve('introdution', path.join(tempDir, 'test.md'), tempDir);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it('should handle Chinese characters in fuzzy matching', async () => {
+      // Create files with similar Chinese names
+      fs.writeFileSync(path.join(tempDir, '知识库.md'), '');
+      fs.mkdirSync(path.join(tempDir, 'chinese'));
+      // '知诓库' (typo) does NOT exist as a file
+
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 3,
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // '知诓库' is 1 edit away from '知识库' (诓 vs 识)
+      const result = fuzzyResolver.resolve('知诓库', path.join(tempDir, 'chinese', 'test.md'), tempDir);
+
+      expect(result.found).toBe(true);
+      expect(result.hasFuzzyMatch).toBe(true);
+      expect(result.file?.basename).toBe('知识库');
+    });
+
+    it('should use exact match over fuzzy match when available', async () => {
+      fs.writeFileSync(path.join(tempDir, 'exact.md'), '');
+      fs.writeFileSync(path.join(tempDir, 'exactt.md'), '');
+
+      const fuzzyResolver = new LinkResolver({
+        caseInsensitive: true,
+        fuzzyMatch: true,
+        fuzzyMaxDistance: 3,
+        warnOnFuzzyMatch: false,
+      });
+      await fuzzyResolver.buildIndex([tempDir]);
+
+      // 'exact' should match exactly, not fuzzy to 'exactt'
+      const result = fuzzyResolver.resolve('exact', path.join(tempDir, 'test.md'), tempDir);
+
+      expect(result.found).toBe(true);
+      expect(result.hasFuzzyMatch).toBeUndefined();
+      expect(result.file?.basename).toBe('exact');
+    });
+
+    it('should prefer subdirectory file when resolving from same subdir', async () => {
+      // 'note.md' exists in 'sub/' directory
+      const resolver = new LinkResolver({
+        caseInsensitive: true,
+        conflictStrategy: 'nearest',
+      });
+      await resolver.buildIndex([tempDir]);
+
+      // From sub/test.md, resolve 'note' - should get sub/note.md
+      // (note.md doesn't exist in root, only in sub/)
+      const result = resolver.resolve('note', path.join(tempDir, 'sub', 'test.md'), tempDir);
+
+      expect(result.found).toBe(true);
+      expect(result.file?.relativePath).toBe('sub/note.md');
+    });
+  });
 });

--- a/tests/unit/domain/link/WikiLink.test.ts
+++ b/tests/unit/domain/link/WikiLink.test.ts
@@ -186,4 +186,75 @@ describe('WikiLink', () => {
       expect(matches).toContain('![[image.png]]');
     });
   });
+
+  describe('resolvePath', () => {
+    it('should resolve wiki link target to file path', () => {
+      const link = WikiLink.parse('[[MyNote]]');
+      expect(link).not.toBeNull();
+
+      // Create a mock resolver
+      const mockResolver = {
+        resolve: jest.fn().mockReturnValue({
+          found: true,
+          file: {
+            absolutePath: '/root/MyNote.md',
+            relativePath: 'MyNote.md',
+            basename: 'MyNote',
+            filename: 'MyNote.md',
+          },
+          relativePath: './MyNote.md',
+          isBroken: false,
+        }),
+      };
+
+      const result = link!.resolvePath(mockResolver as any, '/root/test.md', '/root');
+
+      expect(mockResolver.resolve).toHaveBeenCalledWith('MyNote', '/root/test.md', '/root');
+      expect(result.found).toBe(true);
+      expect(result.file?.basename).toBe('MyNote');
+    });
+
+    it('should handle heading in resolvePath', () => {
+      const link = WikiLink.parse('[[MyNote#Introduction]]');
+      expect(link).not.toBeNull();
+      expect(link!.heading).toBe('Introduction');
+      expect(link!.target).toBe('MyNote');
+
+      const mockResolver = {
+        resolve: jest.fn().mockReturnValue({
+          found: true,
+          file: {
+            absolutePath: '/root/MyNote.md',
+            relativePath: 'MyNote.md',
+            basename: 'MyNote',
+            filename: 'MyNote.md',
+          },
+          relativePath: './MyNote.md',
+          isBroken: false,
+        }),
+      };
+
+      link!.resolvePath(mockResolver as any, '/root/test.md', '/root');
+
+      // Note: resolvePath passes the target (without heading) to the resolver
+      // The heading is preserved in the WikiLink and handled separately
+      expect(mockResolver.resolve).toHaveBeenCalledWith('MyNote', '/root/test.md', '/root');
+    });
+
+    it('should handle broken link in resolvePath', () => {
+      const link = WikiLink.parse('[[Nonexistent]]');
+
+      const mockResolver = {
+        resolve: jest.fn().mockReturnValue({
+          found: false,
+          isBroken: true,
+        }),
+      };
+
+      const result = link!.resolvePath(mockResolver as any, '/root/test.md', '/root');
+
+      expect(result.found).toBe(false);
+      expect(result.isBroken).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implement WikiLink path resolution enhancement as described in Issue #11:

- **Fuzzy matching with Levenshtein distance**: When exact match fails, find similar files using edit distance calculation
- **WikiLink.resolvePath() method**: Convenience method added to WikiLink class for link resolution
- **Conflict resolution improvement**: When multiple files have the same basename, prefer the nearest one based on path distance

## Changes

### LinkResolver
- Added `fuzzyMatch`, `fuzzyMaxDistance`, `warnOnFuzzyMatch` options to `LinkResolverOptions`
- Added `hasFuzzyMatch` and `fuzzyMatchDistance` fields to `LinkResolutionResult`
- Implemented `levenshteinDistance()` method for edit distance calculation
- Implemented `findFuzzyMatch()` method to find best candidate when exact match fails
- Added `handleFuzzyMatchWarning()` for fuzzy match warnings
- Fixed conflict resolution to prefer nearest file even when exact path match exists

### WikiLink
- Added `resolvePath()` method for convenient link resolution using LinkResolver

## Test Coverage

Added 11 new tests covering:
- Fuzzy matching disabled by default
- Fuzzy matching with various edit distances
- Chinese character fuzzy matching
- Exact match preference over fuzzy match
- Nearest file preference when resolving from subdirectory
- Warning on fuzzy match (configurable)

## Configuration

```typescript
const resolver = new LinkResolver({
  fuzzyMatch: true,           // Enable fuzzy matching (default: false)
  fuzzyMaxDistance: 3,        // Max Levenshtein distance (default: 3)
  warnOnFuzzyMatch: true,     // Warn when fuzzy match used (default: true)
  conflictStrategy: 'nearest', // Prefer nearest file (default: 'nearest')
});
```

Closes #11