### PR TITLE
feat: auto-generate frontmatter title from filename

### DIFF
--- a/src/application/convert/Converter.ts
+++ b/src/application/convert/Converter.ts
@@ -119,7 +119,9 @@ export class Converter {
     this.calloutConverter = new CalloutConverter();
 
     // Initialize frontmatter processor
-    this.frontmatterProcessor = new FrontmatterProcessor();
+    this.frontmatterProcessor = new FrontmatterProcessor({
+      autoTitle: config.autoTitle,
+    });
   }
 
   /**
@@ -252,7 +254,7 @@ export class Converter {
       // 1. Process frontmatter
       content = this.frontmatterProcessor.processContent(content, {
         convertWikiLinks: true,
-      });
+      }, filePath);
 
       // 2. Process WikiLinks (note-to-note links)
       const wikiLinkResult = this.wikiLinkProcessor.process(content, filePath, sourceRoot);

--- a/src/domain/frontmatter/FrontmatterProcessor.ts
+++ b/src/domain/frontmatter/FrontmatterProcessor.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as yaml from 'yaml';
 
 /**
@@ -40,6 +41,8 @@ export interface FrontmatterProcessorOptions {
   fieldMappings?: Record<string, string>;
   /** Fields to remove from output */
   removeFields?: string[];
+  /** Auto-generate title from filename if not present */
+  autoTitle?: boolean;
 }
 
 /**
@@ -64,6 +67,11 @@ export interface FrontmatterResult {
 export class FrontmatterProcessor {
   private static readonly FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/;
   private static readonly EMPTY_FRONTMATTER_REGEX = /^---\r?\n---\r?\n/;
+  private readonly autoTitle: boolean;
+
+  constructor(options: FrontmatterProcessorOptions = {}) {
+    this.autoTitle = options.autoTitle ?? true;
+  }
 
   /**
    * Parse frontmatter from content
@@ -181,15 +189,45 @@ export class FrontmatterProcessor {
   /**
    * Process content: parse frontmatter and convert it
    */
-  processContent(content: string, options: FrontmatterProcessorOptions = {}): string {
+  processContent(content: string, options: FrontmatterProcessorOptions = {}, filePath?: string): string {
     const result = this.parse(content);
 
-    if (!result.hasFrontmatter) {
+    // Handle auto-title generation - use option if provided, otherwise fall back to instance setting
+    const shouldAutoTitle = options.autoTitle !== undefined ? options.autoTitle : this.autoTitle;
+    if (shouldAutoTitle && filePath && !result.frontmatter.title) {
+      const title = this.generateTitleFromFilePath(filePath);
+      result.frontmatter.title = title;
+    }
+
+    if (!result.hasFrontmatter && !result.frontmatter.title) {
       return content;
     }
 
     const convertedFrontmatter = this.convert(result.frontmatter, options);
+
+    // If no frontmatter existed but we have a title to add
+    if (!result.hasFrontmatter && result.frontmatter.title) {
+      return convertedFrontmatter + content;
+    }
+
     return convertedFrontmatter + content.slice(result.end);
+  }
+
+  /**
+   * Generate a title from file path
+   * Converts "my_note.md" to "My Note", "hello-world.md" to "Hello World"
+   */
+  generateTitleFromFilePath(filePath: string): string {
+    const basename = path.basename(filePath, path.extname(filePath));
+    // Replace underscores, hyphens, and other separators with spaces
+    // Then capitalize first letter of each word
+    return basename
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .split(' ')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(' ');
   }
 
   /**

--- a/src/infrastructure/config/Config.ts
+++ b/src/infrastructure/config/Config.ts
@@ -89,6 +89,8 @@ export interface Config {
   incremental?: IncrementalConfig;
   /** Custom transformer configuration */
   transformer?: TransformerConfig;
+  /** Auto-generate title from filename if not present in frontmatter (default: true) */
+  autoTitle?: boolean;
 }
 
 /**

--- a/tests/fixtures/expected/11-deep-nested.md
+++ b/tests/fixtures/expected/11-deep-nested.md
@@ -1,3 +1,6 @@
+---
+title: 11 Deep Nested
+---
 # Deep Nested Note
 
 This is a deeply nested note.

--- a/tests/unit/domain/frontmatter/FrontmatterProcessor.test.ts
+++ b/tests/unit/domain/frontmatter/FrontmatterProcessor.test.ts
@@ -7,6 +7,126 @@ describe('FrontmatterProcessor', () => {
     processor = new FrontmatterProcessor();
   });
 
+  describe('constructor', () => {
+    it('should default autoTitle to true', () => {
+      const defaultProcessor = new FrontmatterProcessor();
+      const content = '# No frontmatter\n\nContent';
+      const result = defaultProcessor.processContent(content, {}, '/path/to/my_note.md');
+      expect(result).toContain('title: My Note');
+    });
+
+    it('should accept autoTitle: false in constructor', () => {
+      const disabledProcessor = new FrontmatterProcessor({ autoTitle: false });
+      const content = '# No frontmatter\n\nContent';
+      const result = disabledProcessor.processContent(content, {}, '/path/to/my_note.md');
+      expect(result).not.toContain('title:');
+    });
+  });
+
+  describe('auto-title generation', () => {
+    // AC1: File without frontmatter - auto-generate frontmatter with title
+    it('AC1: should auto-generate frontmatter with title when file has no frontmatter', () => {
+      const content = '# Hello World\n\nContent here';
+      const result = processor.processContent(content, {}, '/path/to/my_note.md');
+
+      expect(result).toMatch(/^---\ntitle: My Note\n---\n/);
+      expect(result).toContain('# Hello World');
+    });
+
+    // AC2: File with frontmatter but no title - add title
+    it('AC2: should add title to existing frontmatter when title is missing', () => {
+      const content = `---
+tags:
+  - note
+---
+# Content`;
+      const result = processor.processContent(content, {}, '/path/to/my_note.md');
+
+      expect(result).toContain('title: My Note');
+      expect(result).toContain('tags:');
+    });
+
+    // AC3: File with title - keep original title
+    it('AC3: should preserve existing title without modification', () => {
+      const content = `---
+title: Existing Title
+tags:
+  - note
+---
+# Content`;
+      const result = processor.processContent(content, {}, '/path/to/my_note.md');
+
+      expect(result).toContain('title: Existing Title');
+      expect(result).not.toContain('title: My Note');
+    });
+
+    // AC4: Filename conversion (underscores, spaces, hyphens)
+    it('AC4: should convert underscores to spaces in filename for title', () => {
+      const content = '# Content';
+      const result = processor.processContent(content, {}, '/path/to/my_note.md');
+      expect(result).toContain('title: My Note');
+    });
+
+    it('AC4: should convert hyphens to spaces in filename for title', () => {
+      const content = '# Content';
+      const result = processor.processContent(content, {}, '/path/to/hello-world.md');
+      expect(result).toContain('title: Hello World');
+    });
+
+    it('AC4: should handle multiple underscores and spaces', () => {
+      const content = '# Content';
+      const result = processor.processContent(content, {}, '/path/to/my__note___file.md');
+      expect(result).toContain('title: My Note File');
+    });
+
+    it('AC4: should capitalize first letter of each word', () => {
+      const content = '# Content';
+      const result = processor.processContent(content, {}, '/path/to/lowercase-note.md');
+      expect(result).toContain('title: Lowercase Note');
+    });
+
+    // AC5: Config can disable the feature via processContent options
+    it('AC5: should respect autoTitle: false in processContent options', () => {
+      const content = '# No frontmatter\n\nContent';
+      const result = processor.processContent(content, { autoTitle: false }, '/path/to/my_note.md');
+      expect(result).not.toContain('title:');
+    });
+
+    it('AC5: should generate title when autoTitle: true even if constructor is false', () => {
+      const disabledProcessor = new FrontmatterProcessor({ autoTitle: false });
+      const content = '# No frontmatter\n\nContent';
+      const result = disabledProcessor.processContent(content, { autoTitle: true }, '/path/to/my_note.md');
+      expect(result).toContain('title: My Note');
+    });
+  });
+
+  describe('generateTitleFromFilePath', () => {
+    it('should convert underscores to spaces', () => {
+      const title = processor.generateTitleFromFilePath('/path/to/my_note.md');
+      expect(title).toBe('My Note');
+    });
+
+    it('should convert hyphens to spaces', () => {
+      const title = processor.generateTitleFromFilePath('/path/to/hello-world.md');
+      expect(title).toBe('Hello World');
+    });
+
+    it('should handle multiple separators', () => {
+      const title = processor.generateTitleFromFilePath('my__note---file.md');
+      expect(title).toBe('My Note File');
+    });
+
+    it('should trim whitespace', () => {
+      const title = processor.generateTitleFromFilePath('  my note  ');
+      expect(title).toBe('My Note');
+    });
+
+    it('should capitalize first letter of each word', () => {
+      const title = processor.generateTitleFromFilePath('hello world');
+      expect(title).toBe('Hello World');
+    });
+  });
+
   describe('parse', () => {
     it('should parse basic frontmatter', () => {
       const content = `---


### PR DESCRIPTION
## Summary

Add automatic title generation for files without frontmatter title (Issue #34).

### Changes

- **FrontmatterProcessor**: Added `autoTitle` option and `generateTitleFromFilePath()` method
- **Converter**: Pass `filePath` to `frontmatterProcessor.processContent()` for auto-title
- **Config**: Added `autoTitle?: boolean` configuration option

### Acceptance Criteria

- ✅ AC1: File without frontmatter - auto-generates frontmatter with title from filename
- ✅ AC2: File with frontmatter but no title - adds title to existing frontmatter  
- ✅ AC3: File with existing title - preserves original title
- ✅ AC4: Filename conversion (underscores → spaces, hyphens → spaces, proper capitalization)
- ✅ AC5: Config can disable this feature via `autoTitle: false`

### Backward Compatibility

Enabled by default (`autoTitle: true` as default in FrontmatterProcessor constructor).

Closes #34